### PR TITLE
Add SortStrategyFactory and enum for sorting abstraction

### DIFF
--- a/Datastructure_and_Algorithmen/AlgorithmenUnitests/SortStrategyFactoryTests.cs
+++ b/Datastructure_and_Algorithmen/AlgorithmenUnitests/SortStrategyFactoryTests.cs
@@ -1,0 +1,25 @@
+﻿using Common;
+using SortingAlgorithms;
+
+namespace AlgorithmenUnitests
+{
+    [TestFixture]
+    public class SortStrategyFactoryTests
+    {
+        [Test]
+        public void Create_Returns_BubbleSort_For_Bubble_Type()
+        {
+            var strategy = SortStrategyFactory.Create<int>(SortStrategyType.Bubble);
+
+            Assert.That(strategy, Is.TypeOf<BubbleSortStrategy<int>>());
+        }
+
+        [Test]
+        public void Create_Returns_InsertionSort_For_Insertion_Type()
+        {
+            var strategy = SortStrategyFactory.Create<int>(SortStrategyType.Insertion);
+
+            Assert.That(strategy, Is.TypeOf<InsertionSortStrategy<int>>());
+        }
+    }
+}

--- a/Datastructure_and_Algorithmen/Common/SortStrategyType.cs
+++ b/Datastructure_and_Algorithmen/Common/SortStrategyType.cs
@@ -1,0 +1,8 @@
+﻿namespace Common
+{
+    public enum SortStrategyType
+    {
+        Bubble,
+        Insertion
+    }
+}

--- a/Datastructure_and_Algorithmen/Datastructure/DoubleLinkedList.cs
+++ b/Datastructure_and_Algorithmen/Datastructure/DoubleLinkedList.cs
@@ -9,11 +9,16 @@ namespace Datastructure
         private Node<T>? _Tail;
         private int _Count;
 
-        private ISortStrategy<T> _SortStrategy = new BubbleSortStrategy<T>();
+        private ISortStrategy<T> _SortStrategy = SortStrategyFactory.Create<T>(SortStrategyType.Bubble);
 
         public void SetSortStrategy(ISortStrategy<T> strategy)
         {
             _SortStrategy = strategy;
+        }
+
+        public void SetSortStrategy(SortStrategyType strategyType)
+        {
+            _SortStrategy = SortStrategyFactory.Create<T>(strategyType);
         }
 
         public void Sort()

--- a/Datastructure_and_Algorithmen/SortingAlgorithms/SortStrategyFactory.cs
+++ b/Datastructure_and_Algorithmen/SortingAlgorithms/SortStrategyFactory.cs
@@ -1,0 +1,16 @@
+﻿using Common;
+
+namespace SortingAlgorithms
+{
+    public static class SortStrategyFactory
+    {
+        public static ISortStrategy<T> Create<T>(SortStrategyType strategyType) where T : IComparable<T>
+        {
+            return strategyType switch
+            {
+                SortStrategyType.Insertion => new InsertionSortStrategy<T>(),
+                _ => new BubbleSortStrategy<T>()
+            };
+        }
+    }
+}


### PR DESCRIPTION
Introduce SortStrategyType enum and SortStrategyFactory to decouple sorting algorithm selection from DoubleLinkedList. Add SetSortStrategy(SortStrategyType) for easier strategy switching. Include unit tests to verify factory behavior. This improves extensibility and maintainability of sorting logic.